### PR TITLE
clippy: use clamp in camera.rs

### DIFF
--- a/src/game/camera.rs
+++ b/src/game/camera.rs
@@ -65,8 +65,8 @@ impl GameCamera {
             let max = min + Vec2::new(playable.w, playable.h);
 
             self.player_rects.push(Rect::new(
-                rect.x.max(min.x).min(max.x),
-                rect.y.max(min.y).min(max.y),
+                rect.x.clamp(min.x, max.x),
+                rect.y.clamp(min.y, max.y),
                 rect.w,
                 rect.h,
             ));


### PR DESCRIPTION
Rational:
```
warning: clamp-like pattern without using clamp function
  --> src/game/camera.rs:68:17
   |
68 |                 rect.x.max(min.x).min(max.x),
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `rect.x.clamp(min.x, max.x)`
   |
   = note: clamp will panic if max < min, min.is_nan(), or max.is_nan()
   = note: clamp returns NaN if the input is NaN
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp
   = note: `#[warn(clippy::manual_clamp)]` on by default

warning: clamp-like pattern without using clamp function
  --> src/game/camera.rs:69:17
   |
69 |                 rect.y.max(min.y).min(max.y),
   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with clamp: `rect.y.clamp(min.y, max.y)`
   |
   = note: clamp will panic if max < min, min.is_nan(), or max.is_nan()
   = note: clamp returns NaN if the input is NaN
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#manual_clamp
```