### PR TITLE
clippy: use into_values in mod.rs

### DIFF
--- a/src/json/map/mod.rs
+++ b/src/json/map/mod.rs
@@ -91,11 +91,7 @@ impl From<Map> for MapDef {
             })
             .collect();
 
-        let tilesets = other
-            .tilesets
-            .into_iter()
-            .map(|(_, tileset)| tileset)
-            .collect();
+        let tilesets = other.tilesets.into_values().collect();
 
         MapDef {
             background_color: other.background_color,


### PR DESCRIPTION
rationale:

```
warning: iterating on a map's values
  --> src/json/map/mod.rs:94:24
   |
94 |           let tilesets = other
   |  ________________________^
95 | |             .tilesets
96 | |             .into_iter()
97 | |             .map(|(_, tileset)| tileset)
   | |________________________________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#iter_kv_map
   = note: `#[warn(clippy::iter_kv_map)]` on by default
help: try
   |
94 ~         let tilesets = other
95 +             .tilesets.into_values()
   |
```