### PR TITLE
clippy: use replace with arg-list

### DIFF
--- a/src/resources.rs
+++ b/src/resources.rs
@@ -496,7 +496,7 @@ impl Resources {
 }
 
 pub fn map_name_to_filename(name: &str) -> String {
-    name.replace(' ', "_").replace('.', "_").to_lowercase()
+    name.replace([' ', '.'], "_").to_lowercase()
 }
 
 pub fn is_valid_map_file_name(file_name: &str) -> bool {


### PR DESCRIPTION
Rationale:
```
warning: used consecutive `str::replace` call
   --> src/resources.rs:499:10
    |
499 |     name.replace(' ', "_").replace('.', "_").to_lowercase()
    |          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: replace with: `replace([' ', '.'], "_")`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#collapsible_str_replace
    = note: `#[warn(clippy::collapsible_str_replace)]` on by default
```